### PR TITLE
add update to numpy scipy installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 install:
   - pip install --upgrade pip setuptools wheel
-  - pip install --only-binary=numpy,scipy numpy scipy
+  - pip install --upgrade --only-binary=numpy,scipy numpy scipy
   - pip install networkx
   - pip install xlrd
   - pip install pandas


### PR DESCRIPTION
The pre-installed numpy version in the travis environment was used
previously. This changes the environment to contain an updated
version.