### PR TITLE
rename BES attributes to clarify a change to lists

### DIFF
--- a/pycity_base/classes/supply/building_energy_system.py
+++ b/pycity_base/classes/supply/building_energy_system.py
@@ -36,16 +36,16 @@ class BES(object):
         self._kind = "bes"
         
         # Initialize all devices as empty lists
-        self.batteries = []
+        self.battery_units = []
         self.boilers = []
-        self.chps = []
+        self.chp_units = []
         self.electrical_heaters = []
         self.heatpumps = []
         self.compression_chillers = []
-        self.inverter_acdcs = []
-        self.inverter_dcacs = []
-        self.pvs = []
-        self.tess = []
+        self.inverters_acdc = []
+        self.inverters_dcac = []
+        self.pv_units = []
+        self.tes_units = []
         
         # The new BES is still empty
         self.has_battery = False
@@ -74,7 +74,7 @@ class BES(object):
         >>> myBes.addDevice(myChp)
         """
         if objectInstance.kind == "battery":
-            self.batteries.append(objectInstance)
+            self.battery_units.append(objectInstance)
             self.has_battery = True
         
         elif objectInstance.kind == "boiler":
@@ -82,7 +82,7 @@ class BES(object):
             self.has_boiler = True
         
         elif objectInstance.kind == "chp":
-            self.chps.append(objectInstance)
+            self.chp_units.append(objectInstance)
             self.has_chp = True
         
         elif objectInstance.kind == "electricalheater":
@@ -99,18 +99,18 @@ class BES(object):
         
         elif objectInstance.kind == "inverter":
             if objectInstance.input_AC:
-                self.inverter_acdcs.append(objectInstance)
+                self.inverters_acdc.append(objectInstance)
                 self.has_inverter_acdc = True
             else:
-                self.inverter_dcacs.append(objectInstance)
+                self.inverters_dcac.append(objectInstance)
                 self.has_inverter_dcac = True
         
         elif objectInstance.kind == "pv":
-            self.pvs.append(objectInstance)
+            self.pv_units.append(objectInstance)
             self.has_pv = True
             
         elif objectInstance.kind == "tes":
-            self.tess.append(objectInstance)
+            self.tes_units.append(objectInstance)
             self.has_tes = True
             
     def addMultipleDevices(self, devices):

--- a/pycity_base/classes/supply/building_energy_system.py
+++ b/pycity_base/classes/supply/building_energy_system.py
@@ -36,16 +36,16 @@ class BES(object):
         self._kind = "bes"
         
         # Initialize all devices as empty lists
-        self.battery = []
-        self.boiler = []
-        self.chp = []
-        self.electrical_heater = []
-        self.heatpump = []
-        self.compression_chiller = []
-        self.inverter_acdc = []
-        self.inverter_dcac = []
-        self.pv = []
-        self.tes = []
+        self.batteries = []
+        self.boilers = []
+        self.chps = []
+        self.electrical_heaters = []
+        self.heatpumps = []
+        self.compression_chillers = []
+        self.inverter_acdcs = []
+        self.inverter_dcacs = []
+        self.pvs = []
+        self.tess = []
         
         # The new BES is still empty
         self.has_battery = False
@@ -74,43 +74,43 @@ class BES(object):
         >>> myBes.addDevice(myChp)
         """
         if objectInstance.kind == "battery":
-            self.battery.append(objectInstance)
+            self.batteries.append(objectInstance)
             self.has_battery = True
         
         elif objectInstance.kind == "boiler":
-            self.boiler.append(objectInstance)
+            self.boilers.append(objectInstance)
             self.has_boiler = True
         
         elif objectInstance.kind == "chp":
-            self.chp.append(objectInstance)
+            self.chps.append(objectInstance)
             self.has_chp = True
         
         elif objectInstance.kind == "electricalheater":
-            self.electrical_heater.append(objectInstance)
+            self.electrical_heaters.append(objectInstance)
             self.has_electrical_heater = True
         
         elif objectInstance.kind == "heatpump":
-            self.heatpump.append(objectInstance)
+            self.heatpumps.append(objectInstance)
             self.has_heatpump = True
 
         elif objectInstance.kind == "compressionchiller":
-            self.compression_chiller.append(objectInstance)
+            self.compression_chillers.append(objectInstance)
             self.has_compression_chiller = True
         
         elif objectInstance.kind == "inverter":
             if objectInstance.input_AC:
-                self.inverter_acdc.append(objectInstance)
+                self.inverter_acdcs.append(objectInstance)
                 self.has_inverter_acdc = True
             else:
-                self.inverter_dcac.append(objectInstance)
+                self.inverter_dcacs.append(objectInstance)
                 self.has_inverter_dcac = True
         
         elif objectInstance.kind == "pv":
-            self.pv.append(objectInstance)
+            self.pvs.append(objectInstance)
             self.has_pv = True
             
         elif objectInstance.kind == "tes":
-            self.tes.append(objectInstance)
+            self.tess.append(objectInstance)
             self.has_tes = True
             
     def addMultipleDevices(self, devices):

--- a/pycity_base/examples/example_building_energy_system.py
+++ b/pycity_base/examples/example_building_energy_system.py
@@ -74,14 +74,14 @@ def run_example():
 
     # Check if objects stored in BES are the same as the original objects:
     print()
-    print("Battery: " + str(battery is bes.battery))
-    print("Boiler: " + str(boiler is bes.boiler))
-    print("CHP: " + str(chp is bes.chp))
-    print("Electrical heater: " + str(elh is bes.electrical_heater))
-    print("Inverter AC to DC: " + str(inverter_ac_dc is bes.inverter_acdc))
-    print("Inverter DC to AC: " + str(inverter_dc_ac is bes.inverter_dcac))
-    print("PV: " + str(pv is bes.pv))
-    print("TES: " + str(tes is bes.tes))
+    print("Battery: " + str(battery in bes.batteries))
+    print("Boiler: " + str(boiler in bes.boilers))
+    print("CHP: " + str(chp in bes.chps))
+    print("Electrical heater: " + str(elh in bes.electrical_heaters))
+    print("Inverter AC to DC: " + str(inverter_ac_dc in bes.inverter_acdcs))
+    print("Inverter DC to AC: " + str(inverter_dc_ac in bes.inverter_dcacs))
+    print("PV: " + str(pv in bes.pvs))
+    print("TES: " + str(tes in bes.tess))
 
     bes.getHasDevices(all_devices=True)
 

--- a/pycity_base/examples/example_building_energy_system.py
+++ b/pycity_base/examples/example_building_energy_system.py
@@ -74,14 +74,14 @@ def run_example():
 
     # Check if objects stored in BES are the same as the original objects:
     print()
-    print("Battery: " + str(battery in bes.batteries))
+    print("Battery: " + str(battery in bes.battery_units))
     print("Boiler: " + str(boiler in bes.boilers))
-    print("CHP: " + str(chp in bes.chps))
+    print("CHP: " + str(chp in bes.chp_units))
     print("Electrical heater: " + str(elh in bes.electrical_heaters))
-    print("Inverter AC to DC: " + str(inverter_ac_dc in bes.inverter_acdcs))
-    print("Inverter DC to AC: " + str(inverter_dc_ac in bes.inverter_dcacs))
-    print("PV: " + str(pv in bes.pvs))
-    print("TES: " + str(tes in bes.tess))
+    print("Inverter AC to DC: " + str(inverter_ac_dc in bes.inverters_acdc))
+    print("Inverter DC to AC: " + str(inverter_dc_ac in bes.inverters_dcac))
+    print("PV: " + str(pv in bes.pv_units))
+    print("TES: " + str(tes in bes.tes_units))
 
     bes.getHasDevices(all_devices=True)
 

--- a/pycity_base/examples/example_city_district_stoch.py
+++ b/pycity_base/examples/example_city_district_stoch.py
@@ -186,7 +186,7 @@ def run_example():
 
     #  Access boiler nominal thermal power
     print('Nominal thermal power of boiler in kW:')
-    print(building_1001.bes.boiler.q_nominal / 1000)
+    print(building_1001.bes.boilers[0].q_nominal / 1000)
 
 
 if __name__ == '__main__':

--- a/pycity_base/examples/example_readme.py
+++ b/pycity_base/examples/example_readme.py
@@ -184,7 +184,7 @@ def main(do_plot=True):
 
     #  Access boiler nominal thermal power
     print('Nominal thermal power of boiler in kW:')
-    print(building_1001.bes.boiler[0].q_nominal / 1000)
+    print(building_1001.bes.boilers[0].q_nominal / 1000)
 
 
 def run_example():


### PR DESCRIPTION
- rename the attributes so that the code using them also has to change
- new names clarify that the attributes are lists of entities
- fix examples using these attributes