### PR TITLE
add encoding to np.genfromtxt

### DIFF
--- a/pycity_base/classes/demand/space_heating.py
+++ b/pycity_base/classes/demand/space_heating.py
@@ -180,7 +180,8 @@ class SpaceHeating(pycity_base.classes.demand.load.Load):
 
                 SpaceHeating.sim_prof_data = np.genfromtxt(dpath,
                                                            delimiter='\t',
-                                                           skip_header=2)
+                                                           skip_header=2,
+                                                           encoding="utf-8")
 
                 SpaceHeating.loaded_sim_profile = True
 

--- a/pycity_base/classes/weather.py
+++ b/pycity_base/classes/weather.py
@@ -121,7 +121,7 @@ class Weather(pycity_base.classes.sun.Sun):
                                             'TRY2010_05_Jahr.dat')
 
                 # Read TRY data
-                TRYData = np.genfromtxt(path_TRY, skip_header=38)
+                TRYData = np.genfromtxt(path_TRY, skip_header=38, encoding="utf-8")
 
                 # Save relevant weather data (only extract row 0 to 8760)
                 self.p_ambient = TRYData[0:nb_rows, 9]
@@ -146,7 +146,7 @@ class Weather(pycity_base.classes.sun.Sun):
                     raise AssertionError(msg)
 
                 # Read TRY data
-                TRYData = np.genfromtxt(path_TRY, skip_header=34)
+                TRYData = np.genfromtxt(path_TRY, skip_header=34, encoding="utf-8")
 
                 # Save relevant weather data (only extract row 0 to 8760)
                 self.p_ambient = TRYData[0:nb_rows, 6]
@@ -177,7 +177,8 @@ class Weather(pycity_base.classes.sun.Sun):
                                          'tmy3_744860_new_york_jfk_airport.csv')
 
             weather_data = np.genfromtxt(path_TMY3, skip_header=2, delimiter=",",
-                                         usecols=(4, 7, 10, 25, 31, 37, 40, 46))
+                                         usecols=(4, 7, 10, 25, 31, 37, 40, 46),
+                                         encoding="utf-8")
 
             self.p_ambient = weather_data[0:nb_rows, 6]
             self.phi_ambient = weather_data[0:nb_rows, 5]

--- a/pycity_base/functions/load_el_profiles.py
+++ b/pycity_base/functions/load_el_profiles.py
@@ -33,7 +33,7 @@ def load_non_res_load_data_weekly(path):
         fifth column: repair / metal shop
     """
 
-    data_array = np.genfromtxt(path, delimiter='\t', skip_header=2, usecols=(3, 4, 5, 6, 7))
+    data_array = np.genfromtxt(path, delimiter='\t', skip_header=2, usecols=(3, 4, 5, 6, 7), encoding="utf-8")
     return data_array
 
 
@@ -57,7 +57,7 @@ def load_non_res_load_data_annual(path):
         third column: warehouse
     """
 
-    data_array = np.genfromtxt(path, delimiter='\t', skip_header=2, usecols=(2, 3, 4))
+    data_array = np.genfromtxt(path, delimiter='\t', skip_header=2, usecols=(2, 3, 4), encoding="utf-8")
     return data_array
 
 


### PR DESCRIPTION
resolves #290 

All text files in pyCity are in UTF-8 encoding. Because of this, pyCity does not need to rely on the default encoding when loading input files and can use UTF-8 instead. This adds the encoding of utf-8 to all calls of np.genfromtxt.